### PR TITLE
fix: env vars and don't json stringify

### DIFF
--- a/src/StepFunctionSimulatorServer.ts
+++ b/src/StepFunctionSimulatorServer.ts
@@ -87,6 +87,6 @@ export class StepFunctionSimulatorServer {
       resolve(res.status(200).json(output));
     });
 
-    await sme.execute(startAtState, JSON.stringify(executionInput.input));
+    await sme.execute(startAtState, executionInput.input);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,6 @@ class ServerlessOfflineStepFunctionsPlugin {
       },
     };
 
-    this.injectEnvVars();
     this.mergeOptions();
 
     if (this.options?.enabled === false) {
@@ -53,6 +52,7 @@ class ServerlessOfflineStepFunctionsPlugin {
   }
 
   private start() {
+    this.injectEnvVars();
     // Get Handler and Path of the Local Functions
     const definedStateMachines = this.serverless.service.initialServerlessConfig?.stepFunctions?.stateMachines;
 


### PR DESCRIPTION
Fixes #2 and #3. 

## Description

1. Calls `injectEnvVars` on the `before:offline:start:init` hook so that env vars are resolved. 
2. Removes the `JSON.stringify` call at the start of the step function to mimic AWS.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Testing manually between AWS and this package