### PR TITLE
feat: add parameter processing for waitForTaskToken tasks

### DIFF
--- a/src/StateProcessor.ts
+++ b/src/StateProcessor.ts
@@ -20,6 +20,65 @@ export class StateProcessor {
     return JSON.stringify(result[0]);
   }
 
+  private static validateWaitForTokenParameters(parameters: Record<string, unknown>) {
+    const acceptableParameterProperties = ['FunctionName', 'Payload'];
+
+    if (!parameters.FunctionName) {
+      throw new Error(`The field 'FunctionName' is required but was missing`);
+    }
+
+    Object.keys(parameters).forEach((key) => {
+      if (!acceptableParameterProperties.includes(key)) {
+        throw new Error(`The field "${key}" is not supported by Step Functions`);
+      }
+    });
+  }
+
+  private static isContextObjectPath(path: string) {
+    return path.startsWith('$$.');
+  }
+
+  private static isPathKey(path: any) {
+    return typeof path === 'string' && path.endsWith('.$');
+  }
+
+  public static processWaitForTokenParameters(dataJson: string | undefined | null, parameters: any): string {
+    const inputJson = dataJson || '{}';
+
+    this.validateWaitForTokenParameters(parameters);
+
+    const output = {};
+
+    // TODO: To extract to a recursive function so that every method can use it
+    Object.entries(parameters.Payload).forEach(([key, value]: [string, any]) => {
+      if (this.isPathKey(key)) {
+        if (typeof value !== 'string') {
+          throw new Error(
+            `The value for the field '${key}' must be a STRING that contains a JSONPath but was an ${typeof value}`,
+          );
+        }
+
+        const newKey = key.substring(0, key.length - 2);
+
+        if (this.isContextObjectPath(value)) {
+          output[newKey] = value.substring(3);
+        } else {
+          const result = JSONPath({
+            path: value === undefined ? '$' : value,
+            json: JSON.parse(inputJson),
+          });
+
+          output[newKey] = result[0];
+        }
+      } else {
+        // TODO: Traverse object deeply
+        output[key] = value;
+      }
+    });
+
+    return JSON.stringify(output);
+  }
+
   public static processResultPath(json: string, resultPath?: string): string {
     const result = JSONPath({
       path: resultPath || '$',

--- a/src/StateProcessor.ts
+++ b/src/StateProcessor.ts
@@ -1,4 +1,5 @@
 import { JSONPath } from 'jsonpath-plus';
+import { PayloadTemplate } from '../src/types/State';
 
 export class StateProcessor {
   public static processInputPath(dataJson: string | undefined | null, inputPath: string | null | undefined): string {
@@ -20,7 +21,7 @@ export class StateProcessor {
     return JSON.stringify(result[0]);
   }
 
-  private static validateWaitForTokenParameters(parameters: Record<string, unknown>) {
+  private static validateWaitForTokenParameters(parameters: PayloadTemplate) {
     const acceptableParameterProperties = ['FunctionName', 'Payload'];
 
     if (!parameters.FunctionName) {
@@ -38,19 +39,26 @@ export class StateProcessor {
     return path.startsWith('$$.');
   }
 
-  private static isPathKey(path: any) {
-    return typeof path === 'string' && path.endsWith('.$');
+  private static isPathKey(path: string) {
+    return path.endsWith('.$');
   }
 
-  public static processWaitForTokenParameters(dataJson: string | undefined | null, parameters: any): string {
+  public static processWaitForTokenParameters(
+    dataJson: string | undefined | null,
+    parameters: PayloadTemplate,
+  ): string {
     const inputJson = dataJson || '{}';
 
     this.validateWaitForTokenParameters(parameters);
 
+    if (typeof parameters.Payload !== 'object') {
+      return '{}';
+    }
+
     const output = {};
 
     // TODO: To extract to a recursive function so that every method can use it
-    Object.entries(parameters.Payload).forEach(([key, value]: [string, any]) => {
+    Object.entries(parameters.Payload).forEach(([key, value]: [string, unknown]) => {
       if (this.isPathKey(key)) {
         if (typeof value !== 'string') {
           throw new Error(

--- a/src/StepFunctionSimulatorServer.ts
+++ b/src/StepFunctionSimulatorServer.ts
@@ -87,6 +87,6 @@ export class StepFunctionSimulatorServer {
       resolve(res.status(200).json(output));
     });
 
-    await sme.execute(startAtState, JSON.stringify(executionInput.input));
+    await sme.execute(startAtState, executionInput.input);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import type { ServerlessOfflineHooks } from './types/ServerlessOfflineHooks';
 import { StepFunctionSimulatorServer } from './StepFunctionSimulatorServer';
 import { StateInfoHandler } from './StateInfoHandler';
 import { Logger } from './utils/Logger';
+import { TaskStateDefinition } from './types/State';
 
 class ServerlessOfflineStepFunctionsPlugin {
   public hooks?: ServerlessOfflineHooks;
@@ -102,8 +103,13 @@ class ServerlessOfflineStepFunctionsPlugin {
         let functionName: string | undefined;
         const resource: string | Record<string, string[]> = (stateOptions as any).Resource;
 
+        // TODO: To extract this to a function/class
         if (typeof resource === 'string') {
-          functionName = resource.split('-').slice(-1)[0];
+          if (resource.endsWith('.waitForTaskToken')) {
+            functionName = (stateOptions as TaskStateDefinition).Parameters?.FunctionName?.['Fn::GetAtt'][0];
+          } else {
+            functionName = resource.split('-').slice(-1)[0];
+          }
         } else {
           // probably an object
           for (const [key, value] of Object.entries(resource)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,6 @@ class ServerlessOfflineStepFunctionsPlugin {
       },
     };
 
-    this.injectEnvVars();
     this.mergeOptions();
 
     if (this.options?.enabled === false) {
@@ -53,6 +52,7 @@ class ServerlessOfflineStepFunctionsPlugin {
   }
 
   private start() {
+    this.injectEnvVars();
     // Get Handler and Path of the Local Functions
     const definedStateMachines = this.serverless.service.initialServerlessConfig?.stepFunctions?.stateMachines;
 

--- a/src/stateTasks/exceptions/FailExecutorException.ts
+++ b/src/stateTasks/exceptions/FailExecutorException.ts
@@ -1,5 +1,3 @@
-import { StringMap } from 'aws-sdk/clients/ecs';
-
 export class FailExecutorException extends Error {
   constructor(message: string, public readonly cause?: string, public readonly error?: string) {
     super(message);

--- a/src/stateTasks/executors/TaskExecutor.ts
+++ b/src/stateTasks/executors/TaskExecutor.ts
@@ -41,9 +41,17 @@ export class TaskExecutor implements StateTypeExecutor {
 
   private processInput(json: string | undefined, stateDefinition: TaskStateDefinition): any {
     const proccessedInputJson = StateProcessor.processInputPath(json, stateDefinition.InputPath);
-    // TODO: Parameters Task
 
-    return JSON.parse(proccessedInputJson);
+    let output = '{}';
+
+    if (stateDefinition.Resource.endsWith('.waitForTaskToken')) {
+      output = StateProcessor.processWaitForTokenParameters(proccessedInputJson, stateDefinition.Parameters);
+    } else {
+      // TODO: Process non WaitForToken Parameters
+      // output = StateProcessor.processParameters(proccessedInputJson, stateDefinition.Parameters);
+    }
+
+    return JSON.parse(output);
   }
 
   private processOutput(output: any, stateDefinition: TaskStateDefinition): string {

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -106,10 +106,10 @@ export type TaskCatchRule = {
 
 type TaskStateParameters = {
   FunctionName?: string | { 'Fn::GetAtt': [string, string] };
-  Payload?: any;
+  Payload?: Record<string, unknown>;
 };
 
-type PayloadTemplate = TaskStateParameters & Record<string, unknown>;
+export type PayloadTemplate = TaskStateParameters & Record<string, unknown>;
 
 export type TaskStateDefinition = CommonStateDefinition & {
   Resource: string;

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -104,9 +104,16 @@ export type TaskCatchRule = {
   ResultPath?: string;
 };
 
+type TaskStateParameters = {
+  FunctionName?: string | { 'Fn::GetAtt': [string, string] };
+  Payload?: any;
+};
+
+type PayloadTemplate = TaskStateParameters & Record<string, unknown>;
+
 export type TaskStateDefinition = CommonStateDefinition & {
   Resource: string;
-  Parameters?: string; // TODO: TBD
+  Parameters?: PayloadTemplate;
   ResultPath?: string;
   ResultSelector?: string;
   Retry?: TaskRetryRule[];


### PR DESCRIPTION
## Description

First crack at solving #7. I've tested locally and works as expected for what was implemented. What's still missing: 
- Recursively checking the parameters object (future PR). This will be used for `ResultSelector` as well.
- I'll need to add tests because otherwise it's too hard/long to test manually
- I've added a lot of `TODO`, I'll work on them later. Mostly refactoring, once I've added some tests. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manually 
