### PR TITLE
feat: use inputPath output when no params

### DIFF
--- a/src/stateTasks/executors/TaskExecutor.ts
+++ b/src/stateTasks/executors/TaskExecutor.ts
@@ -44,7 +44,7 @@ export class TaskExecutor implements StateTypeExecutor {
   private processInput(json: string | undefined, stateDefinition: TaskStateDefinition): any {
     const proccessedInputJson = StateProcessor.processInputPath(json, stateDefinition.InputPath);
 
-    let output = '{}';
+    let output = proccessedInputJson;
 
     if (stateDefinition.Parameters && stateDefinition.Resource.endsWith('.waitForTaskToken')) {
       output = StateProcessor.processWaitForTokenParameters(proccessedInputJson, stateDefinition.Parameters);


### PR DESCRIPTION
## Description

Use the input path's output when no params are supplied

No issue for this fix

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Manual test
