### PR TITLE
Fix/wait for task token and error messages

### DIFF
--- a/src/StateMachineExecutor.ts
+++ b/src/StateMachineExecutor.ts
@@ -59,9 +59,9 @@ export class StateMachineExecutor {
         this.logger.log(
           `Step function execution paused. \n Waiting for success or failure with task token "${this.context.Task.Token}"\n`,
         );
-        return executeNextState;
+        return executeNextState.bind(this);
       } else {
-        executeNextState();
+        return executeNextState();
       }
     } catch (error) {
       // TODO: Error Handling for State Errors including FailState. Must be done

--- a/src/StepFunctionSimulatorServer.ts
+++ b/src/StepFunctionSimulatorServer.ts
@@ -81,9 +81,9 @@ export class StepFunctionSimulatorServer {
       // Resume step function
 
       if (this.isSendTaskSuccess(req.body)) {
-        this.logger.log(`Got request for ${JSON.stringify(req.body)}`);
         if (typeof this.pendingStateMachineExecutions[req.body.taskToken] !== 'function') {
-          return res.status(404).json({ message: `No step function to resume with taskToken '${req.body.taskToken}'` });
+          this.logger.log(`No step function to resume with taskToken '${req.body.taskToken}.'`);
+          return;
         }
 
         this.pendingStateMachineExecutions[req.body.taskToken]();

--- a/src/main.ts
+++ b/src/main.ts
@@ -120,7 +120,7 @@ class ServerlessOfflineStepFunctionsPlugin {
         }
 
         if (!functionName) {
-          throw Error();
+          throw Error(`Could not find funciton name for resource ${resource}`);
         }
 
         const { handler } = definedFunctions[functionName];

--- a/src/stateTasks/executors/TaskExecutor.ts
+++ b/src/stateTasks/executors/TaskExecutor.ts
@@ -40,7 +40,7 @@ export class TaskExecutor extends StateTypeExecutor {
   }
 
   public isWaitForTaskToken(resource?: string): boolean {
-    if (resource && resource.endsWith('.waitForTaskToken')) {
+    if (resource && typeof resource === 'string' && resource.endsWith('.waitForTaskToken')) {
       return true;
     }
     return false;


### PR DESCRIPTION
## Description

Fix for `waitForTaskToken` bug I discovered when a middle task is a `waitForToken` lambda.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manually
- [x] Unit tests
