### PR TITLE
feat: add 256kb limit to returned jsons

### DIFF
--- a/src/StateMachineExecutor.ts
+++ b/src/StateMachineExecutor.ts
@@ -7,6 +7,7 @@ import { Logger } from './utils/Logger';
 import { Context } from './Context/Context';
 import { StateContext } from './Context/StateContext';
 import { ContextToJson } from './Context/ContextToJson';
+import { isJsonByteLengthValid } from './utils/isJsonByteLengthValid';
 
 export type ExecuteType = () => Promise<ExecuteType | string | void>;
 
@@ -38,6 +39,14 @@ export class StateMachineExecutor {
       stateExecutorOutput = await typeExecutor.execute(this.context, stateDefinition, inputJson);
 
       this.logger.debug(`StateMachineExecutor - execute1 - ${stateExecutorOutput}`);
+
+      if (isJsonByteLengthValid(stateExecutorOutput.json)) {
+        this.logger.error(
+          `The state/task '${this.context.State.Name}' returned a result with a size exceeding the maximum number of bytes service limit.`,
+        );
+
+        throw new Error('Return result must have size less than or equal to 262144 bytes in UTF-8 encoding');
+      }
 
       if (stateExecutorOutput.End) {
         this.logger.log(`[${this.context.State.Name}] State Machine Ended`);

--- a/src/utils/isJsonByteLengthValid.ts
+++ b/src/utils/isJsonByteLengthValid.ts
@@ -4,5 +4,5 @@ export function isJsonByteLengthValid(json: string): boolean {
   const byteLength = Buffer.byteLength(json);
   const stepFunctionByteSizeLimit = 262144; // 256 Kb according to AWS
 
-  return byteLength === stepFunctionByteSizeLimit;
+  return byteLength <= stepFunctionByteSizeLimit;
 }

--- a/src/utils/isJsonByteLengthValid.ts
+++ b/src/utils/isJsonByteLengthValid.ts
@@ -1,0 +1,8 @@
+import { Buffer } from 'buffer';
+
+export function isJsonByteLengthValid(json: string): boolean {
+  const byteLength = Buffer.byteLength(json);
+  const stepFunctionByteSizeLimit = 262144; // 256 Kb according to AWS
+
+  return byteLength === stepFunctionByteSizeLimit;
+}


### PR DESCRIPTION
## Description

Add 256kb limit to returned jsons on every task/state

Fixes #6

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
