### PR TITLE
flip arg order for comparator functions (inputValue, choiceValue)

### DIFF
--- a/src/stateTasks/executors/ChoiceExecutor.ts
+++ b/src/stateTasks/executors/ChoiceExecutor.ts
@@ -107,23 +107,23 @@ export class ChoiceExecutor extends StateTypeExecutor {
       case 'NumericEquals':
       case 'StringEquals':
       case 'TimestampEquals':
-        return this.checkEquals(choiceValue, inputValue);
+        return this.checkEquals(inputValue, choiceValue);
       case 'NumericGreaterThan':
       case 'StringGreaterThan':
       case 'TimestampGreaterThan':
-        return this.checkGreaterThan(choiceValue, inputValue);
+        return this.checkGreaterThan(inputValue, choiceValue);
       case 'NumericGreaterThanEquals':
       case 'StringGreaterThanEquals':
       case 'TimestampGreaterThanEquals':
-        return this.checkGreaterThanEquals(choiceValue, inputValue);
+        return this.checkGreaterThanEquals(inputValue, choiceValue);
       case 'NumericLessThan':
       case 'StringLessThan':
       case 'TimestampLessThan':
-        return this.checkLowerThan(choiceValue, inputValue);
+        return this.checkLowerThan(inputValue, choiceValue);
       case 'NumericLessThanEquals':
       case 'StringLessThanEquals':
       case 'TimestampLessThanEquals':
-        return this.checkLowerThanEquals(choiceValue, inputValue);
+        return this.checkLowerThanEquals(inputValue, choiceValue);
       default:
         throw new Error();
     }

--- a/src/stateTasks/executors/ChoiceExecutor.ts
+++ b/src/stateTasks/executors/ChoiceExecutor.ts
@@ -103,6 +103,8 @@ export class ChoiceExecutor extends StateTypeExecutor {
 
     // TODO: Find a better way to map the comparators with the methods without using factories or strategy
     switch (comparator) {
+      case "IsPresent":
+        return choiceValue ? inputValue !== undefined : inputValue === undefined;  
       case 'BooleanEquals':
       case 'NumericEquals':
       case 'StringEquals':
@@ -125,7 +127,7 @@ export class ChoiceExecutor extends StateTypeExecutor {
       case 'TimestampLessThanEquals':
         return this.checkLowerThanEquals(inputValue, choiceValue);
       default:
-        throw new Error();
+        throw new Error(`Comparator ${comparator} not implemented`);
     }
   }
 


### PR DESCRIPTION
## Description

Updated to flip order of args being passed to private comparator functions

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- There were no existing test structure for this class
